### PR TITLE
Make url & company name configurable

### DIFF
--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -1,20 +1,23 @@
 ﻿using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace xluhco.web.Controllers
 {
     public class HomeController : Controller
     {
         private IShortLinkRepository _repo;
+        private SiteOptions _siteOptions;
 
-        public HomeController(IShortLinkRepository repo)
+        public HomeController(IShortLinkRepository repo, IOptions<SiteOptions> siteOptions)
         {
             _repo = repo;
+            _siteOptions = siteOptions.Value;
         }
 
         public IActionResult Index()
         {
-            return View();
+            return View(_siteOptions);
         }
 
         public IActionResult List()

--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -23,7 +23,8 @@ namespace xluhco.web.Controllers
         public IActionResult List()
         {
             var orderedLinks = _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
-            return View(orderedLinks);
+            var vm = new ListPageViewModel(orderedLinks, _siteOptions);
+            return View(vm);
         }
     }
 }

--- a/src/xluhco.web/ListPageViewModel.cs
+++ b/src/xluhco.web/ListPageViewModel.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+namespace xluhco.web
+{
+    public class ListPageViewModel
+    {
+        public List<ShortLinkItem> ShortLinkList  { get; }
+        public SiteOptions SiteOptions { get; }
+
+        public ListPageViewModel(List<ShortLinkItem> links, SiteOptions options)
+        {
+            ShortLinkList = links;
+            SiteOptions = options;
+        }
+    }
+}
+

--- a/src/xluhco.web/SiteOptions.cs
+++ b/src/xluhco.web/SiteOptions.cs
@@ -1,0 +1,8 @@
+namespace xluhco.web
+{
+    public class SiteOptions
+    {
+        public string ShortLinkUrl { get; set; }
+        public string CompanyName { get; set; }
+    }
+}

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -29,6 +29,7 @@ namespace xluhco.web
             services.AddSingleton(x => Log.Logger);
             services.Configure<RedirectOptions>(Configuration);
             services.Configure<GoogleAnalyticsOptions>(Configuration);
+            services.Configure<SiteOptions>(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/xluhco.web/Views/Home/Index.cshtml
+++ b/src/xluhco.web/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿
+﻿@model xluhco.web.SiteOptions
 @{
     ViewBag.Title = "Home";
     Layout = "~/Views/Shared/_layout.cshtml";
@@ -7,5 +7,5 @@
     Hello there!
 </h1>
 <p class="subtitle">
-    This is xluh.co, Excella's friendly URL redirect application.
+    This is @Model.ShortLinkUrl, @Model.CompanyName's friendly URL redirect application.
 </p>

--- a/src/xluhco.web/Views/Home/List.cshtml
+++ b/src/xluhco.web/Views/Home/List.cshtml
@@ -1,4 +1,4 @@
-﻿@model List<xluhco.web.ShortLinkItem>
+﻿@model xluhco.web.ListPageViewModel
 @{
     ViewBag.Title = "All the links";
     Layout = "~/Views/Shared/_layout.cshtml";
@@ -20,7 +20,7 @@
             </tr>
         </thead>
         <tbody class="list">
-            @foreach (var item in Model)
+            @foreach (var item in Model.ShortLinkList)
             {
                 <tr>
                     <td class="shortlink">xluh.co/@item.ShortLinkCode</td>

--- a/src/xluhco.web/Views/Home/List.cshtml
+++ b/src/xluhco.web/Views/Home/List.cshtml
@@ -23,7 +23,7 @@
             @foreach (var item in Model.ShortLinkList)
             {
                 <tr>
-                    <td class="shortlink">xluh.co/@item.ShortLinkCode</td>
+                    <td class="shortlink">@Model.SiteOptions.ShortLinkUrl/@item.ShortLinkCode</td>
                     <td class="url"><a href="@item.URL">@item.URL</a></td>
                 </tr>
             }

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,7 +1,10 @@
 {
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 4,
-  "ShortLinkUrl": "xluh.co",
+  "CompanySettings": {
+    "ShortLinkUrl": "xluh.co",
+    "CompanyName": "Excella Consulting"    
+  },
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,6 +1,7 @@
 {
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 4,
+  "ShortLinkUrl": "xluh.co",
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,10 +1,8 @@
 {
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 4,
-  "SiteOptions": {
-    "ShortLinkUrl": "xluh.co",
-    "CompanyName": "Excella Consulting"    
-  },
+  "ShortLinkUrl": "xluh.co",
+  "CompanyName": "Excella Consulting",    
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,7 +1,7 @@
 {
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 4,
-  "CompanySettings": {
+  "SiteOptions": {
     "ShortLinkUrl": "xluh.co",
     "CompanyName": "Excella Consulting"    
   },


### PR DESCRIPTION
Resolves #25.

Creates a new `SiteOptions` class which pulls from the JSON config for the short URL and company name.

Injects & uses those values in the home and list page.