### PR TITLE
Move shortlink filter into span tag

### DIFF
--- a/src/xluhco.web/Views/Home/List.cshtml
+++ b/src/xluhco.web/Views/Home/List.cshtml
@@ -28,7 +28,7 @@
             @foreach (var item in Model)
             {
                 <tr>
-                    <td class="shortlink">@shortLinkUrl/@item.ShortLinkCode</td>
+                    <td>@shortLinkUrl/<span class="shortlink">@item.ShortLinkCode</span></td>
                     <td class="url"><a href="@item.URL">@item.URL</a></td>
                 </tr>
             }


### PR DESCRIPTION
Closes #48.

## Problem

`xluh.co` was being included in the search filter for every short code + URL.

## Solution

Rather than filtering the whole TD, we applied it to a `span` tag. 

Filtering still works, and now the base URL is excluded from that filtering which should make the searches more accurate.