### PR TITLE
Bring CI to anyone who forks this project, using appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,19 @@
 version: 1.0.{build}
 image: Visual Studio 2017
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
 nuget:
   project_feed: true
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+nuget:
+  project_feed: true
+before_build:
+- ps: >-
+    dotnet --version
+
+    cd .\src
+
+    dotnet restore
+build:
+  verbosity: minimal
+deploy: off
+notifications:
+- provider: GitHubPullRequest
+  on_build_success: true
+  on_build_failure: true
+  on_build_status_changed: true


### PR DESCRIPTION
Resolves #46.

The goal is to add every single setup piece we're using from appveyor to the `appveyor.yml` config file.

This will ensure that when people fork this project or re-upload it with a different name, they can get up and running with CI integrated with github quickly.

## Reference
We'll use the [AppVeyor .yml reference guide](https://www.appveyor.com/docs/appveyor-yml/) to accomplish this.