### PR TITLE
In Progress: Stop Escaping URLs

### DIFF
--- a/src/xluhco.web/Views/Home/List.cshtml
+++ b/src/xluhco.web/Views/Home/List.cshtml
@@ -31,7 +31,7 @@
                 <td><span class="icon btn-clipboard" title="Copy" data-clipboard-target="#url-@item.ShortLinkCode">
                     <i class="fa fa-clipboard"></i>
                 </span> @shortLinkUrl/<span class="shortlink">@item.ShortLinkCode</span></td>
-                <td class="url"><a href="@item.URL" id="url-@item.ShortLinkCode">@item.URL</a></td>
+                <td class="url"><a href="@Html.Raw(item.URL)" id="url-@item.ShortLinkCode">@item.URL</a></td>
             </tr>
         }
 

--- a/src/xluhco.web/Views/Redirect/Index.cshtml
+++ b/src/xluhco.web/Views/Redirect/Index.cshtml
@@ -45,6 +45,6 @@
     </script>
 
     <h2>Short Code @Model.ShortLinkCode</h2>
-    <p>Redirecting to @Model.Url</p>
+    <p>Redirecting to @Html.Raw(Model.Url)</p>
 </body>
 </html>

--- a/src/xluhco.web/Views/Redirect/Index.cshtml
+++ b/src/xluhco.web/Views/Redirect/Index.cshtml
@@ -6,7 +6,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>xluh.co -- Redirecting to @Model.Url</title>
+    <title>xluh.co -- Redirecting to @Html.Raw(Model.Url)</title>
 
     <meta name="description" content="xluhco is a URL shortener for Excella (xluh.co, Excella Co, get it?)">
     <meta name="author" content="Sean Killeen">

--- a/src/xluhco.web/Views/Redirect/Index.cshtml
+++ b/src/xluhco.web/Views/Redirect/Index.cshtml
@@ -37,7 +37,7 @@
         gtag('config', '@Model.TrackingCode');
         gtag('event', 'shortLinkView', {
             'shortLinkCode': '@Model.ShortLinkCode',
-            'shortLinkUrl': '@Model.Url',
+            'shortLinkUrl': '@Html.Raw(Model.Url)',
             'event_callback': function() {
                 redirectToUrl();
             }

--- a/src/xluhco.web/Views/Redirect/Index.cshtml
+++ b/src/xluhco.web/Views/Redirect/Index.cshtml
@@ -30,7 +30,7 @@
         function redirectToUrl() {
             if (!alreadyRedirected) {
                 alreadyRedirected = true;
-                window.location.assign("@Model.Url");
+                window.location.assign("@Html.Raw(Model.Url)");
             }
         };
 


### PR DESCRIPTION
Resolves #69 

Thanks @duluca for reporting! 

## Problem

URLs were referenced directly from the model, and MVC helpfully ties to help us escape. 

## Solution

Use `Html.Raw()` to ensure the raw URL is passed in as-is.

## Work Remaining

* [ ] ~~Tests~~ See #71 
* [x] Use Html.Raw throughout to show & display the right URLs. 
* [x] Visual check on links