### PR TITLE
Add "benefits" alias to the HR link

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -78,3 +78,4 @@ tech-update,https://excellalabs.github.io/tech-update/
 dnd-update,https://excellalabs.github.io/tech-update/
 dndupdate,https://excellalabs.github.io/tech-update/
 prez,https://www.eventbrite.com/e/presidents-day-meal-packing-event-tickets-42800819403?aff=HQ
+benefits,https://excellaco.sharepoint.com/internal/HR/SitePages/Home.aspx


### PR DESCRIPTION
I saw a "not found" link for this in the analytics, figured it made sense to add.