### PR TITLE
Add Response Caching

### DIFF
--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -15,11 +15,13 @@ namespace xluhco.web.Controllers
             _repo = repo ?? throw new ArgumentNullException(nameof(repo));
         }
 
+        [ResponseCache(Duration = int.MaxValue)]
         public IActionResult Index()
         {
             return View("Index");
         }
 
+        [ResponseCache(Duration = int.MaxValue)]
         public IActionResult List()
         {
             var orderedLinks = _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();

--- a/src/xluhco.web/Controllers/RedirectController.cs
+++ b/src/xluhco.web/Controllers/RedirectController.cs
@@ -21,6 +21,7 @@ namespace xluhco.web.Controllers
         }
 
         [HttpGet]
+        [ResponseCache(Duration = int.MaxValue)]
         public IActionResult Index(string shortCode)
         {
             _logger.Debug("Entered the redirect for short code {shortCode}", shortCode);

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -39,6 +39,7 @@ namespace xluhco.web
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddResponseCaching();
             services.AddMvc();
             services.AddScoped(ctx => WireUpLogging());
             services.AddScoped<ShortLinkFromCsvRepository>();


### PR DESCRIPTION
Resolves #86. 

We can cache the IIS response indefinitely, because anytime the links change the site is redeployed anyway. No reason not to cache it. :) 