### PR TITLE
Reduce analytics timeout from 4 to 2

### DIFF
--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "TrackingPropertyId": "UA-108259179-1",
-  "SecondsToWaitForAnalytics": 4,
+  "SecondsToWaitForAnalytics": 2,
   "ShortLinkUrl": "xluh.co",
   "CompanyName": "Excella Consulting",
   "CompanyHomePageUrl": "http://excella.com",    


### PR DESCRIPTION
Resolves #88.

If GA hasn't gotten back to us in 2 seconds, it's time to move on.