### PR TITLE
Add shortlinks for rooms & desks

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -85,3 +85,7 @@ exchange,https://excellaco.sharepoint.com/internal/marketing/Staff%20Meetings/Fo
 xchange,https://excellaco.sharepoint.com/internal/marketing/Staff%20Meetings/Forms/AllItems1.aspx?id=%2Finternal%2Fmarketing%2FStaff%20Meetings%2FExchange%20Archive
 health,https://excellaco.sharepoint.com/internal/HR/xhealthian/SitePages/Home.aspx
 xhealthian,https://excellaco.sharepoint.com/internal/HR/xhealthian/SitePages/Home.aspx
+room,https://app.teem.com/booking/#/search?type=room
+rooms,https://app.teem.com/booking/#/search?type=room
+desk,https://app.teem.com/booking/#/index/search?type=desk
+desks,https://app.teem.com/booking/#/index/search?type=desk


### PR DESCRIPTION
Adds `room` / `rooms` and `desk` / `desks` short links that connect to the pages with Teem so that people don't have to remember where to go to find rooms & desks