### PR TITLE
Add plural "printers" link

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -19,6 +19,7 @@ people,https://excellaco.sharepoint.com/search/Pages/peopleresults.aspx#Default=
 sdsa,https://excellaco.sharepoint.com/sacoe/sd/teamsite/SitePages/Home.aspx
 wifi,https://excellaco.sharepoint.com/internal/it/kb/HQ%20wireless.aspx
 printer,https://excellaco.sharepoint.com/internal/it/kb/HQ%20Printer%20Setup.aspx
+printes,https://excellaco.sharepoint.com/internal/it/kb/HQ%20Printer%20Setup.aspx
 portal,https://excellaco.sharepoint.com/SitePages/Home.aspx
 crm,https://excella.insight.ly/User/Login?ReturnUrl=%2F
 blog,https://www.excella.com/insights


### PR DESCRIPTION
Because I kept typing `printers` and had to remember to type `printer`.