### PR TITLE
In Progress: Add authentication for list items

### DIFF
--- a/src/xluhco.web/AzureAdExtensions.cs
+++ b/src/xluhco.web/AzureAdExtensions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    public static class AzureAdAuthenticationBuilderExtensions
+    {
+        public static AuthenticationBuilder AddAzureAd(this AuthenticationBuilder builder)
+            => builder.AddAzureAd(_ => { });
+
+        public static AuthenticationBuilder AddAzureAd(this AuthenticationBuilder builder, Action<AzureAdOptions> configureOptions)
+        {
+            builder.Services.Configure(configureOptions);
+            builder.Services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, ConfigureAzureOptions>();
+            builder.AddOpenIdConnect();
+            return builder;
+        }
+
+        public class AzureAdOptions
+        {
+            public string ClientId { get; set; }
+
+            public string ClientSecret { get; set; }
+
+            public string Instance { get; set; }
+
+            public string Domain { get; set; }
+
+            public string TenantId { get; set; }
+
+            public string CallbackPath { get; set; }
+        }
+
+
+        private class ConfigureAzureOptions : IConfigureNamedOptions<OpenIdConnectOptions>
+        {
+            private readonly AzureAdOptions _azureOptions;
+
+            public ConfigureAzureOptions(IOptions<AzureAdOptions> azureOptions)
+            {
+                _azureOptions = azureOptions.Value;
+            }
+
+            public void Configure(string name, OpenIdConnectOptions options)
+            {
+                options.ClientId = _azureOptions.ClientId;
+                options.Authority = $"{_azureOptions.Instance}{_azureOptions.TenantId}";
+                options.UseTokenLifetime = true;
+                options.CallbackPath = _azureOptions.CallbackPath;
+                options.RequireHttpsMetadata = false;
+            }
+
+            public void Configure(OpenIdConnectOptions options)
+            {
+                Configure(Options.DefaultName, options);
+            }
+        }
+    }
+}

--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using xluhco.web.Repositories;
 
@@ -22,6 +23,7 @@ namespace xluhco.web.Controllers
         }
 
         [ResponseCache(Duration = int.MaxValue)]
+        [Authorize]
         public IActionResult List()
         {
             var orderedLinks = _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -1,10 +1,20 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using xluhco.web.Repositories;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
 
 namespace xluhco.web
 {
@@ -53,6 +63,12 @@ namespace xluhco.web
             services.Configure<RedirectOptions>(Configuration);
             services.Configure<GoogleAnalyticsOptions>(Configuration);
             services.Configure<SiteOptions>(Configuration);
+            services.AddAuthentication(sharedOptions =>
+                {
+                    sharedOptions.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    sharedOptions.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                })
+                .AddAzureAd(options => Configuration.Bind("AzureAd", options));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -9,7 +9,7 @@
     "Domain": "excella.com",
     "TenantId": "0ca95f54-6e24-4f99-a5c6-4b0f5845a7d5",
     "ClientId": "b5604b4a-dfa9-4420-957f-d2368f992fb1",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/.auth/login/aad/callback"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -9,7 +9,7 @@
     "Domain": "excella.com",
     "TenantId": "0ca95f54-6e24-4f99-a5c6-4b0f5845a7d5",
     "ClientId": "b5604b4a-dfa9-4420-957f-d2368f992fb1",
-    "CallbackPath": "/.auth/login/aad/callback"
+    "CallbackPath": "/signin-oidc"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -3,7 +3,14 @@
   "SecondsToWaitForAnalytics": 2,
   "ShortLinkUrl": "xluh.co",
   "CompanyName": "Excella Consulting",
-  "CompanyHomePageUrl": "http://excella.com",    
+  "CompanyHomePageUrl": "http://excella.com",
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "excella.com",
+    "TenantId": "0ca95f54-6e24-4f99-a5c6-4b0f5845a7d5",
+    "ClientId": "b5604b4a-dfa9-4420-957f-d2368f992fb1",
+    "CallbackPath": "/signin-oidc"
+  },
   "Logging": {
     "IncludeScopes": false,
     "Debug": {


### PR DESCRIPTION
## Description

Companies may prefer to add authentication to their list of links, so that only authenticated users can view the entirety of the list. 

This PR aims to:

* Add a Setting for authentication type ("None", "AzureAD", etc.)
* Add settings specific to Azure AD
* Wire up authentication based on settings. 
* Update documentation to describe how to make use of the Azure AD portion.

## Work

* [x] Create Azure AD integration
* [x] Test Azure AD functionality locally
* [ ] Get Azure AD to work in an alternate site deployed from this branch (to ensure it will work once merged)
* [ ] Tweak the configuration to ensure site users can specify "None" or "AzureAD" for Auth.
* [ ] Tweak the Azure AD auth to throw smart errors if the values aren't applied