### PR TITLE
Add Azure AD Integration (without locking things down yet)

### DIFF
--- a/src/xluhco.web.tests/xluhco.web.tests.csproj
+++ b/src/xluhco.web.tests/xluhco.web.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/xluhco.web.tests/xluhco.web.tests.csproj
+++ b/src/xluhco.web.tests/xluhco.web.tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AspnetCore.TestHOst" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/src/xluhco.web.tests/xluhco.web.tests.csproj
+++ b/src/xluhco.web.tests/xluhco.web.tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.AspnetCore.TestHOst" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspnetCore.TestHOst" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,9 +1,16 @@
 {
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "excella.com",
+    "TenantId": "0ca95f54-6e24-4f99-a5c6-4b0f5845a7d5",
+    "ClientId": "0b9fd802-91bf-459c-b494-53b68393d026",
+    "CallbackPath": "/signin-oidc"
+  },
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 2,
   "ShortLinkUrl": "xluh.co",
   "CompanyName": "Excella Consulting",
-  "CompanyHomePageUrl": "http://excella.com",    
+  "CompanyHomePageUrl": "http://excella.com",
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="3.4.0" />

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="CsvHelper" Version="3.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
     <PackageReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationInsightsResourceId>/subscriptions/8562adbc-78cd-4694-9dc5-1d1f2d2cf915/resourcegroups/xluhco/providers/microsoft.insights/components/xluhco</ApplicationInsightsResourceId>
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
-    <PackageReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.0" />
@@ -23,7 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="wwwroot\ShortLinks.csv" />

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationInsightsResourceId>/subscriptions/8562adbc-78cd-4694-9dc5-1d1f2d2cf915/resourcegroups/xluhco/providers/microsoft.insights/components/xluhco</ApplicationInsightsResourceId>
     <ApplicationInsightsAnnotationResourceId>/subscriptions/8562adbc-78cd-4694-9dc5-1d1f2d2cf915/resourceGroups/xluhco/providers/microsoft.insights/components/xluhco</ApplicationInsightsAnnotationResourceId>
   </PropertyGroup>

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="3.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="3.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="CsvHelper" Version="3.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
A PR that:

* Updates the .NET Core version 
* Updates the central packages
* Configures AD Auth but does not yet lock anything down.

This is to ensure that we have the basic bits correct before deploying actual auth.