### PR TITLE
Revert "Add Azure AD Integration (without locking things down yet) (#…

### DIFF
--- a/src/xluhco.web.tests/xluhco.web.tests.csproj
+++ b/src/xluhco.web.tests/xluhco.web.tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.AspnetCore.TestHOst" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.AspnetCore.TestHOst" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -1,13 +1,10 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using xluhco.web.Repositories;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.AzureAD.UI;
 
 namespace xluhco.web
 {
@@ -43,17 +40,6 @@ namespace xluhco.web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddResponseCaching();
-
-            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
-                .AddAzureAD(options => Configuration.Bind("AzureAd", options));
-
-            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
-            {
-                options.Authority = options.Authority + "/v2.0/";
-
-                options.TokenValidationParameters.ValidateIssuer = true; // Enforces that it checks for our specific domain
-            });
-
             services.AddMvc();
             services.AddScoped(ctx => WireUpLogging());
             services.AddScoped<ShortLinkFromCsvRepository>();
@@ -78,7 +64,6 @@ namespace xluhco.web
             }
 
             app.UseStaticFiles();
-            app.UseAuthentication();
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -1,16 +1,9 @@
 {
-  "AzureAd": {
-    "Instance": "https://login.microsoftonline.com/",
-    "Domain": "excella.com",
-    "TenantId": "0ca95f54-6e24-4f99-a5c6-4b0f5845a7d5",
-    "ClientId": "0b9fd802-91bf-459c-b494-53b68393d026",
-    "CallbackPath": "/signin-oidc"
-  },
   "TrackingPropertyId": "UA-108259179-1",
   "SecondsToWaitForAnalytics": 2,
   "ShortLinkUrl": "xluh.co",
   "CompanyName": "Excella Consulting",
-  "CompanyHomePageUrl": "http://excella.com",
+  "CompanyHomePageUrl": "http://excella.com",    
   "Logging": {
     "IncludeScopes": false,
     "Debug": {

--- a/src/xluhco.web/xluhco.web.csproj
+++ b/src/xluhco.web/xluhco.web.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <ApplicationInsightsResourceId>/subscriptions/8562adbc-78cd-4694-9dc5-1d1f2d2cf915/resourcegroups/xluhco/providers/microsoft.insights/components/xluhco</ApplicationInsightsResourceId>
     <ApplicationInsightsAnnotationResourceId>/subscriptions/8562adbc-78cd-4694-9dc5-1d1f2d2cf915/resourceGroups/xluhco/providers/microsoft.insights/components/xluhco</ApplicationInsightsAnnotationResourceId>
   </PropertyGroup>
@@ -12,18 +12,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="3.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="3.4.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="wwwroot\ShortLinks.csv" />


### PR DESCRIPTION
Unfortunately, apparently .NET Core runtime v2.1.5 is not yet supported on Azure. 

So, while this worked on my local machine. Azure does not currently have the capability.

Reference: https://blogs.msdn.microsoft.com/dotnet/2018/10/02/net-core-october-2018-update/

This causes an error on the home page & list page (though thankfully redirects still work).

Therefore, reverting and seeing if I can use the 2.1.4 runtime instead.