### PR TITLE
Add auth flag for list action

### DIFF
--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using xluhco.web.Repositories;
 
@@ -21,6 +22,7 @@ namespace xluhco.web.Controllers
             return View("Index");
         }
 
+        [Authorize]
         [ResponseCache(Duration = int.MaxValue)]
         public IActionResult List()
         {


### PR DESCRIPTION
This will lock down the list only to authenticated users. 

I've tried this option locally and it appears to work as expected (though I can't test the callback until it's deployed with the current structure).