### PR TITLE
Use memorycache for links on list page

### DIFF
--- a/src/xluhco.web.tests/Controllers/HomeControllerTests.cs
+++ b/src/xluhco.web.tests/Controllers/HomeControllerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using xluhco.web.Controllers;
 using xluhco.web.Repositories;
@@ -13,19 +14,21 @@ namespace xluhco.web.tests.Controllers
     public class HomeControllerTests
     {
         private readonly Mock<IShortLinkRepository> _mockRepo;
+        private readonly Mock<IMemoryCache> _mockMemoryCache;
         private readonly HomeController _sut;
 
         public HomeControllerTests()
         {
             _mockRepo = new Mock<IShortLinkRepository>();
-            _sut = new HomeController(_mockRepo.Object);
+            _mockMemoryCache = new Mock<IMemoryCache>();
+            _sut = new HomeController(_mockRepo.Object, _mockMemoryCache.Object);
         }
 
         [Fact]
         public void Ctor_NullRepository_ThrowsError()
         {
             // ReSharper disable once ObjectCreationAsStatement
-            Action act = () => new HomeController(null);
+            Action act = () => new HomeController(null, _mockMemoryCache.Object);
 
             act.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("repo");
         }

--- a/src/xluhco.web.tests/Controllers/HomeControllerTests.cs
+++ b/src/xluhco.web.tests/Controllers/HomeControllerTests.cs
@@ -14,13 +14,17 @@ namespace xluhco.web.tests.Controllers
     public class HomeControllerTests
     {
         private readonly Mock<IShortLinkRepository> _mockRepo;
+        private readonly Mock<ICacheEntry> _mockCacheEntry;
         private readonly Mock<IMemoryCache> _mockMemoryCache;
         private readonly HomeController _sut;
 
         public HomeControllerTests()
         {
             _mockRepo = new Mock<IShortLinkRepository>();
+            _mockCacheEntry = new Mock<ICacheEntry>();
             _mockMemoryCache = new Mock<IMemoryCache>();
+            _mockMemoryCache.Setup(x => x.CreateEntry(It.IsAny<object>())).Returns(_mockCacheEntry.Object);
+
             _sut = new HomeController(_mockRepo.Object, _mockMemoryCache.Object);
         }
 
@@ -91,12 +95,13 @@ namespace xluhco.web.tests.Controllers
         [Fact]
         public void List_MultipleItems_ReturnsItemsSortedByShortCode()
         {
-            _mockRepo.Setup(x => x.GetShortLinks()).Returns(new List<ShortLinkItem>()
-            {
-                new ShortLinkItem("ghi", "http://seankilleen.com"),
-                new ShortLinkItem("def", "http://seankilleen.com"),
-                new ShortLinkItem("abc", "http://seankilleen.com")
-            });
+            _mockRepo.Setup(x => x.GetShortLinks()).Returns(
+                new List<ShortLinkItem>()
+                {
+                    new ShortLinkItem("ghi", "http://SeanKilleen.com"),
+                    new ShortLinkItem("def", "http://SeanKilleen.com"),
+                    new ShortLinkItem("abc", "http://SeanKilleen.com")
+                });
 
             var result = _sut.List();
 

--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -28,9 +28,12 @@ namespace xluhco.web.Controllers
         [Authorize]
        public IActionResult List()
         {
+            var orderedLinks = _memoryCache.GetOrCreate("allLinks", entry =>
+            {
+                entry.SlidingExpiration = TimeSpan.MaxValue;
+                return _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
+            });
 
-            var orderedLinks = 
-                _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
             return View("List", orderedLinks);
         }
     }

--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -23,8 +23,7 @@ namespace xluhco.web.Controllers
         }
 
         [Authorize]
-        [ResponseCache(Duration = int.MaxValue)]
-        public IActionResult List()
+       public IActionResult List()
         {
             var orderedLinks = _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
             return View("List", orderedLinks);

--- a/src/xluhco.web/Controllers/HomeController.cs
+++ b/src/xluhco.web/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using xluhco.web.Repositories;
 
 namespace xluhco.web.Controllers
@@ -10,10 +11,12 @@ namespace xluhco.web.Controllers
     public class HomeController : Controller
     {
         private readonly IShortLinkRepository _repo;
+        private readonly IMemoryCache _memoryCache;
 
-        public HomeController(IShortLinkRepository repo)
+        public HomeController(IShortLinkRepository repo, IMemoryCache memoryCache)
         {
             _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+            _memoryCache = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
         }
 
         [ResponseCache(Duration = int.MaxValue)]
@@ -25,7 +28,9 @@ namespace xluhco.web.Controllers
         [Authorize]
        public IActionResult List()
         {
-            var orderedLinks = _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
+
+            var orderedLinks = 
+                _repo.GetShortLinks().OrderBy(x => x.ShortLinkCode).ToList();
             return View("List", orderedLinks);
         }
     }

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -43,7 +43,7 @@ namespace xluhco.web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddResponseCaching();
-
+            services.AddMemoryCache();
             services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
                 .AddAzureAD(options => Configuration.Bind("AzureAd", options));
 


### PR DESCRIPTION
I didn't like the idea of using output caching for the results, because I wasn't sure if the output would be cached even for auth that had expired, etc.

Rather than worrying about those complex policies, I figure we'll just cache at a different level, so I put the link retrieval behind an `IMemoryCache`. Easy enough!