### PR TITLE
Add description to Gene Kim link

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -130,4 +130,4 @@ fellow,https://excellaco.sharepoint.com/sites/innovationteam/_layouts/15/WopiFra
 csdsurvey,https://docs.google.com/forms/d/e/1FAIpQLSd-r4lYiQIZ3cRrvdVg73SkheZHNOk4cMX2kWjDAdKO93o4yA/viewform?usp=sf_link
 map,https://excella.teem.com/manage/#/flightboards/flightboard?floor_id=15575&mode=map&types=room%2Cdesk
 bonus,https://excellaco.sharepoint.com/internal/HR/teamsite/Excella%20Employee%20Guide/Compensation.aspx
-genekim,https://www.eventbrite.com/e/meet-gene-kim-author-of-the-unicorn-project-tickets-59902026574
+genekim,https://www.eventbrite.com/e/meet-gene-kim-author-of-the-unicorn-project-tickets-59902026574,,Meet Gene Kim -- Author of The Unicorn Project,on April 24 Join Excella and Gene Kim -- a multi-award winning CTO and author -- to discuss his new book: The Unicorn Project

--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -130,4 +130,4 @@ fellow,https://excellaco.sharepoint.com/sites/innovationteam/_layouts/15/WopiFra
 csdsurvey,https://docs.google.com/forms/d/e/1FAIpQLSd-r4lYiQIZ3cRrvdVg73SkheZHNOk4cMX2kWjDAdKO93o4yA/viewform?usp=sf_link
 map,https://excella.teem.com/manage/#/flightboards/flightboard?floor_id=15575&mode=map&types=room%2Cdesk
 bonus,https://excellaco.sharepoint.com/internal/HR/teamsite/Excella%20Employee%20Guide/Compensation.aspx
-genekim,https://www.eventbrite.com/e/meet-gene-kim-author-of-the-unicorn-project-tickets-59902026574,,Meet Gene Kim -- Author of The Unicorn Project,on April 24 Join Excella and Gene Kim -- a multi-award winning CTO and author -- to discuss his new book: The Unicorn Project
+genekim,https://www.eventbrite.com/e/meet-gene-kim-author-of-the-unicorn-project-tickets-59902026574,https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F59722734%2F240396618780%2F1%2Foriginal.20190404-175956?w=800&auto=compress&rect=0%2C0%2C2160%2C1080&s=9721f9992b9d5a997fd6bec10aff13a8,Meet Gene Kim -- Author of The Unicorn Project,on April 24 Join Excella and Gene Kim -- a multi-award winning CTO and author -- to discuss his new book: The Unicorn Project


### PR DESCRIPTION
The gene kim link is showing up on LinkedIn and Slack as:

> ![image](https://user-images.githubusercontent.com/2148318/55689973-7a47d480-5959-11e9-8d11-3689412dc145.png)

That's not ideal. So I added a title and description from the event.

/cc @sgilhuley as FYI