### PR TITLE
Update Finance short link to use home page

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -4,7 +4,7 @@ atx,https://www.excella.com/about/arlington-tech-exchange
 team,http://www.excella.com/about/our-team
 nest,https://excellaco.sharepoint.com/internal/HR/teamsite/nest/SitePages/Home.aspx
 x5,https://excellaco.sharepoint.com/internal/marketing/marketing2017/Pages/X5-Nominations.aspx
-finance,https://excellaco.sharepoint.com/internal/finance/reporting/SitePages/Home.aspx
+finance,https://excellaco.sharepoint.com/internal/finance/teamsite/SitePages/Home2.0.aspx
 cal,https://excellaco.sharepoint.com/Lists/Corp%20Aggregate%20Calendar/calendar.aspx
 calendar,https://excellaco.sharepoint.com/Lists/Corp%20Aggregate%20Calendar/calendar.aspx
 x10,https://excellaco.sharepoint.com/internal/corporate/planning/Pages/X10.aspx


### PR DESCRIPTION
Update to finance link only. Was pointing at 2018 data, now going to more user friendly finance homepage. 