### PR TITLE
Add links to Outlook online

### DIFF
--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -142,6 +142,6 @@ unanetsummarizer,https://excellalabs.github.io/unanet-summarizer
 unanet-summarizer,https://excellalabs.github.io/unanet-summarizer
 summarizer,https://excellalabs.github.io/unanet-summarizer
 unasum,https://excellalabs.github.io/unanet-summarizer
-email,https://outlook.office.com/mail/inbox
-mail,https://outlook.office.com/mail/inbox
-outlook,https://outlook.office.com/mail/inbox
+email,https://outlook.office.com
+mail,https://outlook.office.com
+outlook,https://outlook.office.com

--- a/src/xluhco.web/wwwroot/ShortLinks.csv
+++ b/src/xluhco.web/wwwroot/ShortLinks.csv
@@ -142,3 +142,6 @@ unanetsummarizer,https://excellalabs.github.io/unanet-summarizer
 unanet-summarizer,https://excellalabs.github.io/unanet-summarizer
 summarizer,https://excellalabs.github.io/unanet-summarizer
 unasum,https://excellalabs.github.io/unanet-summarizer
+email,https://outlook.office.com/mail/inbox
+mail,https://outlook.office.com/mail/inbox
+outlook,https://outlook.office.com/mail/inbox


### PR DESCRIPTION
I figured there already had to be a link to Outlook online and these are the three things I tried before pulling up the list of URLs. I'm suggesting that we point `mail`, `email`, and `outlook` all at https://outlook.office.com