### PR TITLE
Add cookie policy (and some other tweaks)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services: # these are all the services that a docker app uses
+
+  app: # this is the name of the service we're creating; it's chosen by us.
+    container_name: 'xluhco_site' # this is the name of the container to us
+    hostname: 'xluhco_site'
+    build:
+      context: ./src
+      dockerfile: Dockerfile
+    ports:
+    - "5000:80"
+    networks:
+      - app-network
+      
+networks:
+  app-network:
+    driver: bridge

--- a/src/xluhco.web/Startup.cs
+++ b/src/xluhco.web/Startup.cs
@@ -10,6 +10,8 @@ using Serilog;
 using xluhco.web.Repositories;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.CookiePolicy;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 
 namespace xluhco.web
@@ -91,6 +93,7 @@ namespace xluhco.web
                 app.UseDeveloperExceptionPage();
             }
 
+            app.UseCookiePolicy();
             app.UseStaticFiles();
             app.UseAuthentication();
             app.UseMvc(routes =>

--- a/src/xluhco.web/appsettings.json
+++ b/src/xluhco.web/appsettings.json
@@ -15,13 +15,17 @@
     "IncludeScopes": false,
     "Debug": {
       "LogLevel": {
-        "Default": "Warning"
-      }
+        "Default": "Information",
+        "System": "Information",
+        "Microsoft": "Information"
+        }
     },
     "Console": {
       "LogLevel": {
-        "Default": "Warning"
-      }
+        "Default": "Information",
+        "System": "Information",
+        "Microsoft": "Information"
+        }
     }
   },
   "ApplicationInsights": {


### PR DESCRIPTION
Supports #259.

* Calls to apply cookie policy which should use sensible defaults in .NET Core 3.1 (and works for me int the local container)

Other incidentals:

* Makes the logging more verbose
* Adds a `docker-compose.yml` file because I prefer typing `docker-compose build; docker-compose up`.