### PR TITLE
Add guidance on editing links

### DIFF
--- a/EditLinks.md
+++ b/EditLinks.md
@@ -1,0 +1,10 @@
+# Editing Links on Excella's Instance of Excellaco
+
+Excella has opted to keep its CSV private within cloud storage, so editing links directly in the repo isn't currently an option.
+
+Your options for adding/editing links are:
+
+* If you have access to the storage, you can edit the CSV file directly there.
+* You can post in the `#xluhco` channel within Excella's Slack.
+* You can [file a new issue](https://github.com/excellalabs/xluhco/issues/new/choose) and choose `Request a Link`
+* You can contact @luis-m-gonzalez.


### PR DESCRIPTION
A markdown file that shows people where to go. I'll update the blob to update the `editlinks` shortlink to point to here (it previously went to the CSV file.)